### PR TITLE
shared device activation - applies to windows only

### DIFF
--- a/DeployOffice/overview-of-shared-computer-activation-for-office-365-proplus.md
+++ b/DeployOffice/overview-of-shared-computer-activation-for-office-365-proplus.md
@@ -22,6 +22,9 @@ description: "Shared computer activation lets you to deploy Office 365 ProPlus t
 
 # Overview of shared computer activation for Office 365 ProPlus
 
+**Applies to**
+-   Windows
+
 > [!IMPORTANT]
 > This information is intended for administrators and IT Pros. For information about activating a personal copy of Office, see [Activate Office 365, Office 2016, or Office 2013](https://support.office.com/article/5bd38f38-db92-448b-a982-ad170b1e187e). 
   


### PR DESCRIPTION
Added applies to section and specified windows as it is my understanding this does not apply to Mac OS.