### PR TITLE
Update configuration-options-for-the-office-2016-deployment-tool.md

### DIFF
--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -116,7 +116,7 @@ Allowed values:
 
 ### Channel attribute (part of Add element) 
 
-Optional. Defines which channel to use for installing Office. The default is **Broad** for Office 365 ProPlus and **Monthly** for Visio Pro for Office 365 and Project Online Desktop Client. 
+Optional. Defines which channel to use for installing Office. The default is **Broad** for Office 365 ProPlus and applies to Visio Pro for Office 365 and Project Online Desktop client if deployed along with Office 365 ProPlus.  The default is **Monthly** for Visio Pro for Office 365 and Project Online Desktop Client if deployed standalone without Office 365 ProPlus. 
 
 For more information about update channels, see  [Overview of update channels for Office 365 ProPlus](overview-of-update-channels-for-office-365-proplus.md).  
 


### PR DESCRIPTION
I think it makes sense to explain this behavior when deploying Visio and Project with the suite or without the suite.


### Channel attribute (part of Add element) 

Optional. Defines which channel to use for installing Office. The default is **Broad** for Office 365 ProPlus and applies to Visio Pro for Office 365 and Project Online Desktop client if deployed along with Office 365 ProPlus.  The default is **Monthly** for Visio Pro for Office 365 and Project Online Desktop Client if deployed standalone without Office 365 ProPlus.