### PR TITLE
> symbol missing at the end of the <Add

### DIFF
--- a/DeployOffice/overview-of-deploying-languages-in-office-365-proplus.md
+++ b/DeployOffice/overview-of-deploying-languages-in-office-365-proplus.md
@@ -52,7 +52,7 @@ For details on how to edit the configuration file, see [Configuration options fo
 
 ### Example
 ```
-<Add SourcePath="\\Server\Share" 
+<Add> SourcePath="\\Server\Share" 
      OfficeClientEdition="32"
      Channel="Broad" 
      AllowCdnFallback="True">


### PR DESCRIPTION
The greater sign is missing at the end of <Add
The correct code has to be <Add>