### PR TITLE
Update to EnableOffice365ConfigService policy

### DIFF
--- a/DeployOffice/deploy-office-365-proplus-in-gcc-high-dod.md
+++ b/DeployOffice/deploy-office-365-proplus-in-gcc-high-dod.md
@@ -173,6 +173,9 @@ The following registry values must to be set to correctly configure Outlook beha
 
   **Registry location:** HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover\EnableOffice365ConfigService <br/>
   **Description:** This is needed so that the correct mailbox settings may be retrieved in this specific environment without calling a worldwide service to retrieve mailbox settings.<br/>
+  
+> [!NOTE]
+> As of build 16.0.9327.1000, the EnableOffice365ConfigService policy is no longer used.
 
   **Registry location:** HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Setup\DisableAccountSettingsDetectionService <br/>
   **Description:** This disables calling a worldwide service that assists in getting account information for POP, IMAP, and other protocols based on the email address. Because this service will be disabled by this key, personal accounts will need to be set up manually.  <br/>


### PR DESCRIPTION
Starting with build 16.0.9327.1000 there's no need to set this policy.
See: https://support.microsoft.com/en-us/help/3211279/outlook-2016-implementation-of-autodiscover