### PR TITLE
Use the Channel attribute when specifying the Version attribute

### DIFF
--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -95,15 +95,14 @@ Example values:
 - SourcePath="\\\server\share\"
 - SourcePath="c:\preload\office"
 
-### Version attribute (part of Add element) *
+### Version attribute (part of Add element)
 
-Optional. The default is the latest available version of Office.
+Optional. The default is the latest available version of Office. When you use the Version attribute, we recommend including the Channel attribute as well. If you don't include the Channel attribute, the default channel will be used, which might not match the specified version.
 
 Example value:
 
 - Version="16.0.8201.2193"
 
-* When using the Version attribute, the Channel attribute also needs to be used
 
 ### OfficeClientEdition attribute (part of Add element) 
 

--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -95,13 +95,15 @@ Example values:
 - SourcePath="\\\server\share\"
 - SourcePath="c:\preload\office"
 
-### Version attribute (part of Add element) 
+### Version attribute (part of Add element) *
 
 Optional. The default is the latest available version of Office.
 
 Example value:
 
 - Version="16.0.8201.2193"
+
+* When using the Version attribute, the Channel attribute also needs to be used
 
 ### OfficeClientEdition attribute (part of Add element) 
 


### PR DESCRIPTION
the Channel attribute should also be used. If someone specifies a Monthly Channel version using the Version attribute but do not specify the Channel attribute, setup.exe attepts to download the Monthly cab from the Semi-Annual URL. The installer lgo would show the following error:-

"Download failed for current transport\",\"SourcePath\":\"http://officecdn.microsoft.com/db/7ffbc6bf-bc32-4f92-8982-f9dd17fd3114/Office/Data/v64_16.0.11601.20178.cab

The above log excerpt showed I tried to download a particular Monthly version of Office without specifying the Channel and the installer attempted to find, unsuccessfully, the cab file from the Deffered CDN URL 7ffbc6bf-bc32-4f92-8982-f9dd17fd3114