### PR TITLE
Add retail flavor of Visio/Project product ID's

### DIFF
--- a/DeployOffice/upgrade-from-msi-version.md
+++ b/DeployOffice/upgrade-from-msi-version.md
@@ -90,7 +90,10 @@ The following are examples of supported IDs for Project and Visio:
 - PrjPro
 - VisStd
 - VisPro
-
+- PrjStdR
+- PrjProR
+- VisStdR
+- VisProR
 
 > [!NOTE]
 > The product ID is the Setup ID that is found in the Setup.xml file in the *{product}*.WW folder of the installation files for your previous version of Office. For example, the Setup.xml file for Office Professional Plus 2010 is found in the ProPlus.WW folder. 


### PR DESCRIPTION
Martin Nothnagel suggested documenting the -r flavor product ID's as we see upgrades failing when customers have deployed retail or MSDN versions of the product.