### PR TITLE
Update configuration-options-for-the-office-2016-deployment-tool.md

### DIFF
--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -523,7 +523,13 @@ For more information, see  [Overview of the Office Deployment Tool](overview-of-
   </Product>
 </Remove>
 ```
+If you want to uninstall a full product with all installed languages, you can leave out the language section. ODT will automatically discover all installed languages for this product and remove them. This can be used when you don't want to uninstall all products, but just a specific one. Otherwise use the "All" attribute. The following example would uninstall Visio with all languages and leave all other products (e.g. Office 365 ProPlus) untouched.
 
+```xml
+<Remove All="FALSE">
+  <Product ID="VisioProRetail" />
+</Remove>
+```
 
 ### All attribute (part of Remove element)
 

--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -510,7 +510,7 @@ Allowed values:
 
 ## Remove element
 
-Defines which products and languages to remove from a previous installation of Office 365 ProPlus. To remove an installed language, you must provide both the product and the language, as in the example. 
+Defines which products and languages to remove from a previous installation of Office 365 ProPlus. To remove an installed language, you must provide both the product and the language, as in the example. If you want to uninstall a full product and all the installed languages, do not include the language attribute. In that case, the ODT  automatically removes all installed languages for the product. 
 
 For more information, see  [Overview of the Office Deployment Tool](overview-of-the-office-2016-deployment-tool.md).
 
@@ -523,14 +523,6 @@ For more information, see  [Overview of the Office Deployment Tool](overview-of-
   </Product>
 </Remove>
 ```
-If you want to uninstall a full product with all installed languages, you can leave out the language section. ODT will automatically discover all installed languages for this product and remove them. This can be used when you don't want to uninstall all products, but just a specific one. Otherwise use the "All" attribute. The following example would uninstall Visio with all languages and leave all other products (e.g. Office 365 ProPlus) untouched.
-
-```xml
-<Remove All="FALSE">
-  <Product ID="VisioProRetail" />
-</Remove>
-```
-
 ### All attribute (part of Remove element)
 
 If set to **TRUE**, all Office 365 ProPlus products and languages will be removed.

--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -510,7 +510,7 @@ Allowed values:
 
 ## Remove element
 
-Defines which products and languages to remove from a previous installation of Office 365 ProPlus. To remove an installed language, you must provide both the product and the language, as in the example. If you want to uninstall a full product and all the installed languages, do not include the language attribute. In that case, the ODT  automatically removes all installed languages for the product. 
+Defines which products and languages to remove from a previous installation of Office 365 ProPlus. To remove an installed language, you must provide both the product and the language, as in the example. To remove all the installed languages, do not include the language attribute. In that case, the ODT automatically discovers and removes all installed languages for the product. 
 
 For more information, see  [Overview of the Office Deployment Tool](overview-of-the-office-2016-deployment-tool.md).
 


### PR DESCRIPTION
Remove-section > Added the missing information that Remove can be used without specifying a language and it will autosnap to the installed languages.