### PR TITLE
Amending previous name M365 Business Premium

### DIFF
--- a/DeployOffice/overview-shared-computer-activation.md
+++ b/DeployOffice/overview-shared-computer-activation.md
@@ -41,7 +41,7 @@ To use shared computer activation, you need an Office 365 (or Microsoft 365) pla
 
 - Any plan that include Microsoft 365 Apps for enterprise (previously named Office 365 Plus). For example, Office 365 E3 or Microsoft 365 E5.
 - Any plan that includes the desktop version of Project or Visio. For example, Project Plan 3 or Visio Plan 2.
-- The Microsoft 365 Business Premium plan, which includes Microsoft 365 Apps for business (previously named Office 365 Business).
+- The Microsoft 365 Business Premium plan, which includes Microsoft 365 Apps for business (previously named Microsoft 365 Business).
   
 > [!NOTE]
 > - The Microsoft 365 Business Premium plan is the only business plan that includes support for shared computer activation. There are other business plans, such as Microsoft 365 Business Standard, that include Microsoft 365 Apps for business, But, those business plans don't include support for shared computer activation.


### PR DESCRIPTION
In April, we renamed the Office 365 plans as follows:

Office 365 Business Premium > Microsoft 365 Business Standard
Microsoft 365 Business > Microsoft 365 Business Premium

The former doesn't include Shared Computer Activation, but the latter does. I suggest we correct the previous name from 'Office 365 Business' to 'Microsoft 365 Business' to avoid confusion/ambiguity.

Source: https://www.microsoftpartnercommunity.com/t5/UK-Modern-Workplace-Community/Office-365-subscriptions-for-SMB-will-be-renamed-as-Microsoft/gpm-p/18540#M103