### PR TITLE
Update microsoft-365-apps-health.md

### DIFF
--- a/DeployOffice/admincenter/microsoft-365-apps-health.md
+++ b/DeployOffice/admincenter/microsoft-365-apps-health.md
@@ -19,7 +19,7 @@ description: "Provides Office admins information about Microsoft 365 Apps health
 The Microsoft 365 Apps health dashboard in the [Microsoft 365 Apps admin center](https://config.office.com) monitors reliability and performance metrics and provides custom guidance to help optimize and troubleshoot Microsoft 365 Apps on your client devices. 
 
 Requirements:
-- Microsoft 365 Apps for enterprise, Version 2007 or later
+- Microsoft 365 Apps for enterprise, Version 1908 or later
 - A version of Windows 10 supported by Microsoft 365 Apps for enterprise
 - Microsoft 365 (or Office 365) A3, A5, E3, or E5 subscription plan
 


### PR DESCRIPTION
Updating requirements to indicate minimum supported version "1908". 1908 (SAC) is the oldest version officially supported by Microsoft across all channels.

From a purely technical perspective, the dashboard would also show data for customers running versions as old as "Monthly" (now Current) 1904 however, by now, those versions should be largely deprecated.