### PR TITLE
Update volume-license-serializer.md

### DIFF
--- a/DeployOffice/mac/volume-license-serializer.md
+++ b/DeployOffice/mac/volume-license-serializer.md
@@ -44,7 +44,7 @@ Then, deploy and run the VL Serializer package file on each computer that you wa
 - Because the license plist file is encrypted using information from the computer on which it's installed, you can't copy it to a different computer to activate Office on that computer.
 - There's a single VL Serializer package that contains a single key that's shared between all volume licensed customer installations.
 - The VL Serializer package contains a binary executable that's named "Microsoft Office Setup Assistant." It's this executable that actually activates the volume license.
-- The VL Serializer package is compatible with mobile device management (MDM) servers such as Microsoft Intune, Jamf Pro, or FileWave.
+- The VL Serializer package is compatible with mobile device management (MDM) servers such as Jamf Pro, or FileWave.
 
 
 ## Related articles

--- a/DeployOffice/mac/volume-license-serializer.md
+++ b/DeployOffice/mac/volume-license-serializer.md
@@ -44,7 +44,7 @@ Then, deploy and run the VL Serializer package file on each computer that you wa
 - Because the license plist file is encrypted using information from the computer on which it's installed, you can't copy it to a different computer to activate Office on that computer.
 - There's a single VL Serializer package that contains a single key that's shared between all volume licensed customer installations.
 - The VL Serializer package contains a binary executable that's named "Microsoft Office Setup Assistant." It's this executable that actually activates the volume license.
-- The VL Serializer package is compatible with mobile device management (MDM) servers such as Jamf Pro, or FileWave.
+- The VL Serializer package is compatible with mobile device management (MDM) servers, such as Jamf Pro or FileWave.
 
 
 ## Related articles


### PR DESCRIPTION
I cannot confirm that Jamf or Filewave are able to deploy this or not, but deploying pkg files as lob apps requires all .pkg to install under ./applications - this pkg doesn't

https://docs.microsoft.com/en-us/troubleshoot/mem/intune/macos-lob-apps-not-deployed
Currently, support for macOS app deployment is limited to simple .pkg apps that are installed in the /Applications folder and Office 365 apps for macOS.

https://github.com/msintuneappsdk/intune-app-wrapping-tool-mac/issues/33
Packages that might have multiple installs within that each have their own bundleID seem to not allow Intune to report back the app is installed and gives an error about one or more apps containing invalid bundleIDs (0x87d13ba2).

https://docs.microsoft.com/en-us/mem/intune/apps/lob-apps-macos#step-4---review--create
If the .pkg file contains multiple apps or app installers, then Microsoft Intune will only report that the app is successfully installed when all installed apps are detected on the device.

https://docs.microsoft.com/en-us/troubleshoot/mem/intune/macos-lob-apps-not-deployed#resolution
To fix the issue, contact your app developer to rebuild the .pkg package to include the required information.

It seems one .pkg installs in a temp folder and the other at the root, they'd both need to be under ./applications to be detected as successful.