### PR TITLE
Update office-deployment-tool-configuration-options.md

### DIFF
--- a/DeployOffice/office-deployment-tool-configuration-options.md
+++ b/DeployOffice/office-deployment-tool-configuration-options.md
@@ -98,7 +98,9 @@ When you download Office to a folder that already contains that version of Offic
 Example values:
 
 - SourcePath="\\\server\share\"
-- SourcePath="c:\preload\office"
+- SourcePath="c:\preload\"
+
+The SourcePath value should not include the /Office part or the name of the folder on which Office Data have been downloaded.
 
 ### Version attribute (part of Add element)
 

--- a/DeployOffice/office-deployment-tool-configuration-options.md
+++ b/DeployOffice/office-deployment-tool-configuration-options.md
@@ -98,7 +98,7 @@ When you download Office to a folder that already contains that version of Offic
 Example values:
 
 - SourcePath="\\\server\share\"
-- SourcePath="c:\preload\"
+- SourcePath="C:\Downloads\Microsoft"
 
 The SourcePath value should not include the /Office part or the name of the folder on which Office Data have been downloaded.
 


### PR DESCRIPTION
When SourcePath is pointing to a file path, the value should not include the actually folder that the data have been downloaded. This will result into an error from the setup, which is not useful on systems that do not have access to internet. Systems that do have access to internet will skip the error and download the data from CDN. In a mass installation that may lead into network bandwidth issues.