### PR TITLE
Add auto-labeling to the analyze content table

### DIFF
--- a/DeployOffice/privacy/connected-experiences.md
+++ b/DeployOffice/privacy/connected-experiences.md
@@ -31,6 +31,7 @@ The following table provides a list of connected experiences that analyze your c
 | 3D Maps <sup>[1]</sup>    | [Get started with 3D Maps](https://support.microsoft.com/office/6b56a50d-3c3e-4a9e-a527-eea62a387030)   |
 | Analyze Data | [Analyze Data in Excel](https://support.microsoft.com/office/3223aab8-f543-4fda-85ed-76bb0295ffc4) |
 | Automatic alt txt   | [Everything you need to know to write effective alt text](https://support.microsoft.com/office/df98f884-ca3d-456c-807b-1a1fa82f5dc2) |
+| Auto-apply or recommend sensitivity labels | [Sensitivity labels are automatically applied or recommended for your files and emails in Office](https://support.microsoft.com/office/622e0d9c-f38c-470a-bcdb-9e90b24d71a1)
 |Chart recommendations|[Create a chart with recommended charts](https://support.microsoft.com/office/cd131b77-79c7-4537-a438-8db20cea84c0)|
 |Class Notebook add-ins|[Getting Started with the OneNote Class Notebook: A Walkthrough for Teachers](https://support.microsoft.com/office/28666b8e-b0ae-48fe-b001-1874f5f6db58)|
 | Data types| [Excel data types: Stocks and geography](https://support.microsoft.com/office/61a33056-9935-484f-8ac8-f1a89e210877)   |


### PR DESCRIPTION
@DHB-MSFT  The automatic/recommended sensitivity labeling feature is a connected experience that analyzes content via M365 services, but was not listed in the table, so I added it. This is a feature above and beyond the basic sensitivity labeling capabilities that are already part of the "other connected experiences" table.