### PR TITLE
Update requirements-licenses.md

### DIFF
--- a/DeployOffice/admincenter/includes/requirements-licenses.md
+++ b/DeployOffice/admincenter/includes/requirements-licenses.md
@@ -15,7 +15,7 @@ Your user must be assigned to one of the following subscription plans:
 | ---------- | ----------------- |
 | Education  | <li>Microsoft 365 A3</li><li>Microsoft 365 A5</li>
 | Business   | <li>Microsoft 365 Business Standard</li><li>Microsoft 365 Business Premium</li>
-| Enterprise | <li>Microsoft 365 E3</li><li>Microsoft 365 E5</li>
+| Enterprise | <li>Office 365 E3</li><li>Office 365 E5</li><li>Microsoft 365 E3</li><li>Microsoft 365 E5</li>
 
 > [!IMPORTANT]
 > The following plans are not supported:


### PR DESCRIPTION
Office 365 E3 and Microsoft 365 E3 are different types of licenses, as described in the content below.  Product names and service plan identifiers for licensing - Microsoft Entra ID | Microsoft Learn

Customer made misunderstanding that the Office 365 E3 and the Office 365 E5 do not meet the requirements for cloud updates cased on the current license description,